### PR TITLE
Updating LLVM support to 3.8.1.

### DIFF
--- a/src/LibLLVM/BuildLlvmWithVS.cmd
+++ b/src/LibLLVM/BuildLlvmWithVS.cmd
@@ -14,7 +14,7 @@ set LLVM_ROOT=%~d0%~p0
 set GENERATE=1
 set BUILD=1
 set REGISTER=1
-set LlvmVersion=3.8.0
+set LlvmVersion=3.8.1
 
 @REM - Allow overriding default version and disabling any of the stages via parameters
 :arg_loop
@@ -90,7 +90,7 @@ goto :exit
 @echo     -g- disables the cmake project generation phase
 @echo     -b- disables the code build phase 
 @echo     -r- disables the registry update
-@echo     -v ^<LlvmVersion^> sets the LLVM version number used for the registry entry (Default is 3.8.0)
+@echo     -v ^<LlvmVersion^> sets the LLVM version number used for the registry entry (Default is 3.8.1)
 @echo.
 @echo The registry entry is used by the LlvmApplication.props Propertysheet for VC projects to locate the various
 @echo LLVM headers and libs. Alternatively, if LLVM_SRCROOT_DIR is provided either as an environment variable

--- a/src/LibLLVM/LlvmApplication.props
+++ b/src/LibLLVM/LlvmApplication.props
@@ -9,7 +9,7 @@
         -->
     <LlvmVersionMajor Condition="'$(LlvmVersionMajor)'==''">3</LlvmVersionMajor>
     <llvmVersionMinor Condition="'$(llvmVersionMinor)'==''">8</llvmVersionMinor>
-    <LlvmVersionBuild Condition="'$(LlvmVersionBuild)'==''">0</LlvmVersionBuild>
+    <LlvmVersionBuild Condition="'$(LlvmVersionBuild)'==''">1</LlvmVersionBuild>
     <LLVM_VERSION Condition="'$(LLVM_VERSION)'==''">$(LlvmVersionMajor).$(llvmVersionMinor).$(LlvmVersionBuild)</LLVM_VERSION>
     <!-- Source ROOT Dir contains the full source of LLVM. To support both developer and automated build service
              scenarios try user registry, then HKLM-64 and HKLM-32 in that order

--- a/src/Llvm.NET/LLVM/LLVMNative.cs
+++ b/src/Llvm.NET/LLVM/LLVMNative.cs
@@ -227,7 +227,7 @@ namespace Llvm.NET.Native
             GetVersionInfo( ref versionInfo );
             if( versionInfo.Major != VersionMajor
              || versionInfo.Minor != VersionMinor
-             || versionInfo.Patch != VersionPatch
+             || versionInfo.Patch < VersionPatch
               )
             {
                 throw new BadImageFormatException( "Mismatched LibLLVM version" );


### PR DESCRIPTION
LLVM 3.8.1 i a bug fix only API/ABI compatible update so no significant changes to LLVM.NET.