### PR TITLE
Updates for LLVM 3.9.0. 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,8 +23,8 @@
 # these files as binary and thus will always conflict and require user
 # intervention with every merge. To do so, just uncomment the entries below
 ###############################################################################
-*.sln text eol=crlf merge=binary
-*.*proj text eol=crlf merge=binary
+*.sln text merge=binary
+*.*proj text merge=binary
 
 ###############################################################################
 # behavior for image files

--- a/src/LibLLVM/AttributeBindings.h
+++ b/src/LibLLVM/AttributeBindings.h
@@ -15,6 +15,8 @@
 #define LLVM_BINDINGS_LLVM_ATTRIBUTEBINDINGS_H
 
 #include "llvm-c/Core.h"
+#include "llvm-c/Types.h"
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -24,62 +26,59 @@ extern "C" {
     enum LLVMAttrKind
     {
         // IR-Level Attributes
-        LLVMAttrKindNone,                  ///< No attributes have been set
-        LLVMAttrKindAlignment,             ///< Alignment of parameter (5 bits)
-                                           ///< stored as log2 of alignment with +1 bias
-                                           ///< 0 means unaligned (different from align(1))
-        LLVMAttrKindAlwaysInline,          ///< inline=always
-        LLVMAttrKindBuiltin,               ///< Callee is recognized as a builtin, despite
-                                           ///< nobuiltin attribute on its declaration.
-        LLVMAttrKindByVal,                 ///< Pass structure by value
-        LLVMAttrKindInAlloca,              ///< Pass structure in an alloca
-        LLVMAttrKindCold,                  ///< Marks function as being in a cold path.
-        LLVMAttrKindConvergent,            ///< Can only be moved to control-equivalent blocks
-        LLVMAttrKindInlineHint,            ///< Source said inlining was desirable
-        LLVMAttrKindInReg,                 ///< Force argument to be passed in register
-        LLVMAttrKindJumpTable,             ///< Build jump-instruction tables and replace refs.
-        LLVMAttrKindMinSize,               ///< Function must be optimized for size first
-        LLVMAttrKindNaked,                 ///< Naked function
-        LLVMAttrKindNest,                  ///< Nested function static chain
-        LLVMAttrKindNoAlias,               ///< Considered to not alias after call
-        LLVMAttrKindNoBuiltin,             ///< Callee isn't recognized as a builtin
-        LLVMAttrKindNoCapture,             ///< Function creates no aliases of pointer
-        LLVMAttrKindNoDuplicate,           ///< Call cannot be duplicated
-        LLVMAttrKindNoImplicitFloat,       ///< Disable implicit floating point insts
-        LLVMAttrKindNoInline,              ///< inline=never
-        LLVMAttrKindNonLazyBind,           ///< Function is called early and/or
-                                           ///< often, so lazy binding isn't worthwhile
-        LLVMAttrKindNonNull,               ///< Pointer is known to be not null
-        LLVMAttrKindDereferenceable,       ///< Pointer is known to be dereferenceable
-        LLVMAttrKindDereferenceableOrNull, ///< Pointer is either null or dereferenceable
-        LLVMAttrKindNoRedZone,             ///< Disable redzone
-        LLVMAttrKindNoReturn,              ///< Mark the function as not returning
-        LLVMAttrKindNoUnwind,              ///< Function doesn't unwind stack
-        LLVMAttrKindOptimizeForSize,       ///< opt_size
-        LLVMAttrKindOptimizeNone,          ///< Function must not be optimized.
-        LLVMAttrKindReadNone,              ///< Function does not access memory
-        LLVMAttrKindReadOnly,              ///< Function only reads from memory
-        LLVMAttrKindArgMemOnly,            ///< Funciton can access memory only using pointers
-                                           ///< based on its arguments.
-        LLVMAttrKindReturned,              ///< Return value is always equal to this argument
-        LLVMAttrKindReturnsTwice,          ///< Function can return twice
-        LLVMAttrKindSExt,                  ///< Sign extended before/after call
-        LLVMAttrKindStackAlignment,        ///< Alignment of stack for function (3 bits)
-                                           ///< stored as log2 of alignment with +1 bias 0
-                                           ///< means unaligned (different from
-                                           ///< alignstack=(1))
-        LLVMAttrKindStackProtect,          ///< Stack protection.
-        LLVMAttrKindStackProtectReq,       ///< Stack protection required.
-        LLVMAttrKindStackProtectStrong,    ///< Strong Stack protection.
-        LLVMAttrKindSafeStack,             ///< Safe Stack protection.
-        LLVMAttrKindStructRet,             ///< Hidden pointer to structure to return
-        LLVMAttrKindSanitizeAddress,       ///< AddressSanitizer is on.
-        LLVMAttrKindSanitizeThread,        ///< ThreadSanitizer is on.
-        LLVMAttrKindSanitizeMemory,        ///< MemorySanitizer is on.
-        LLVMAttrKindUWTable,               ///< Function must be in a unwind table
-        LLVMAttrKindZExt,                  ///< Zero extended before/after call
-
-        EndAttrKinds           ///< Sentinal value useful for loops
+        LLVMAttrKindNone,
+        LLVMAttrKindAlignment,
+        LLVMAttrKindAllocSize,
+        LLVMAttrKindAlwaysInline,
+        LLVMAttrKindArgMemOnly,
+        LLVMAttrKindBuiltin,
+        LLVMAttrKindByVal,
+        LLVMAttrKindCold,
+        LLVMAttrKindConvergent,
+        LLVMAttrKindDereferenceable,
+        LLVMAttrKindDereferenceableOrNull,
+        LLVMAttrKindInAlloca,
+        LLVMAttrKindInReg,
+        LLVMAttrKindInaccessibleMemOnly,
+        LLVMAttrKindInaccessibleMemOrArgMemOnly,
+        LLVMAttrKindInlineHint,
+        LLVMAttrKindJumpTable,
+        LLVMAttrKindMinSize,
+        LLVMAttrKindNaked,
+        LLVMAttrKindNest,
+        LLVMAttrKindNoAlias,
+        LLVMAttrKindNoBuiltin,
+        LLVMAttrKindNoCapture,
+        LLVMAttrKindNoDuplicate,
+        LLVMAttrKindNoImplicitFloat,
+        LLVMAttrKindNoInline,
+        LLVMAttrKindNoRecurse,
+        LLVMAttrKindNoRedZone,
+        LLVMAttrKindNoReturn,
+        LLVMAttrKindNoUnwind,
+        LLVMAttrKindNonLazyBind,
+        LLVMAttrKindNonNull,
+        LLVMAttrKindOptimizeForSize,
+        LLVMAttrKindOptimizeNone,
+        LLVMAttrKindReadNone,
+        LLVMAttrKindReadOnly,
+        LLVMAttrKindReturned,
+        LLVMAttrKindReturnsTwice,
+        LLVMAttrKindSExt,
+        LLVMAttrKindSafeStack,
+        LLVMAttrKindSanitizeAddress,
+        LLVMAttrKindSanitizeMemory,
+        LLVMAttrKindSanitizeThread,
+        LLVMAttrKindStackAlignment,
+        LLVMAttrKindStackProtect,
+        LLVMAttrKindStackProtectReq,
+        LLVMAttrKindStackProtectStrong,
+        LLVMAttrKindStructRet,
+        LLVMAttrKindSwiftError,
+        LLVMAttrKindSwiftSelf,
+        LLVMAttrKindUWTable,
+        LLVMAttrKindZExt,
+        EndAttrKinds           /// Sentinal value useful for loops
     };
 
     // These functions replace the LLVM*FunctionAttr functions in the stable C API
@@ -113,7 +112,6 @@ extern "C" {
     * @{
     */
     typedef uintptr_t LLVMAttributeSet;
-    typedef uintptr_t LLVMAttributeValue;
     typedef struct LLVMOpaqueAttributeBuilder* LLVMAttributeBuilderRef;
 
     /** @name AttributeSet 
@@ -140,8 +138,8 @@ extern "C" {
     LLVMBool LLVMAttributeSetHasAttributes( LLVMAttributeSet attributeSet, unsigned index );
     LLVMBool LLVMAttributeSetHasAttributeSomewhere( LLVMAttributeSet attributeSet, LLVMAttrKind kind );
 
-    LLVMAttributeValue LLVMAttributeSetGetAttributeByKind( LLVMAttributeSet attributeSet, unsigned index, LLVMAttrKind kind );
-    LLVMAttributeValue LLVMAttributeSetGetAttributeByName( LLVMAttributeSet attributeSet, unsigned index, char const* name );
+    LLVMAttributeRef LLVMAttributeSetGetAttributeByKind( LLVMAttributeSet attributeSet, unsigned index, LLVMAttrKind kind );
+    LLVMAttributeRef LLVMAttributeSetGetAttributeByName( LLVMAttributeSet attributeSet, unsigned index, char const* name );
     char const* LLVMAttributeSetToString( LLVMAttributeSet attributeSet, unsigned index, LLVMBool inGroup );
 
     unsigned LLVMAttributeSetGetNumSlots( LLVMAttributeSet attributeSet );
@@ -154,7 +152,7 @@ extern "C" {
     void LLVMSetCallSiteAttributeSet( LLVMValueRef /*Instruction*/ instruction, LLVMAttributeSet attributeSet );
 
     uintptr_t LLVMAttributeSetGetIteratorStartToken( LLVMAttributeSet attributeSet, unsigned slot );
-    LLVMAttributeValue LLVMAttributeSetIteratorGetNext( LLVMAttributeSet attributeSet, unsigned slot, uintptr_t* pToken );
+    LLVMAttributeRef LLVMAttributeSetIteratorGetNext( LLVMAttributeSet attributeSet, unsigned slot, uintptr_t* pToken );
 
     /**
     * @}
@@ -163,19 +161,19 @@ extern "C" {
     /** @name Attribute
     * @{
     */
-    LLVMBool LLVMIsEnumAttribute( LLVMAttributeValue attribute );
-    LLVMBool LLVMIsIntAttribute( LLVMAttributeValue attribute );
-    LLVMBool LLVMIsStringAttribute( LLVMAttributeValue attribute );
-    LLVMBool LLVMHasAttributeKind( LLVMAttributeValue attribute, LLVMAttrKind kind );
-    LLVMBool LLVMHasAttributeString( LLVMAttributeValue attribute, char const* name );
-    LLVMAttrKind LLVMGetAttributeKind( LLVMAttributeValue attribute );
-    uint64_t LLVMGetAttributeValue( LLVMAttributeValue attribute );
-    char const* LLVMGetAttributeName( LLVMAttributeValue attribute );
-    char const* LLVMGetAttributeStringValue( LLVMAttributeValue attribute );
-    char const* LLVMAttributeToString( LLVMAttributeValue attribute );
+    LLVMBool LLVMIsEnumAttribute( LLVMAttributeRef attribute );
+    LLVMBool LLVMIsIntAttribute( LLVMAttributeRef attribute );
+    LLVMBool LLVMIsStringAttribute( LLVMAttributeRef attribute );
+    LLVMBool LLVMHasAttributeKind( LLVMAttributeRef attribute, LLVMAttrKind kind );
+    LLVMBool LLVMHasAttributeString( LLVMAttributeRef attribute, char const* name );
+    LLVMAttrKind LLVMGetAttributeKind( LLVMAttributeRef attribute );
+    uint64_t LLVMGetAttributeValue( LLVMAttributeRef attribute );
+    char const* LLVMGetAttributeName( LLVMAttributeRef attribute );
+    char const* LLVMGetAttributeStringValue( LLVMAttributeRef attribute );
+    char const* LLVMAttributeToString( LLVMAttributeRef attribute );
 
-    LLVMAttributeValue LLVMCreateAttribute( LLVMContextRef ctx, LLVMAttrKind kind, uint64_t value );
-    LLVMAttributeValue LVMCreateTargetDependentAttribute( LLVMContextRef ctx, char const* name, char const* value );
+    LLVMAttributeRef LLVMCreateAttribute( LLVMContextRef ctx, LLVMAttrKind kind, uint64_t value );
+    LLVMAttributeRef LVMCreateTargetDependentAttribute( LLVMContextRef ctx, char const* name, char const* value );
     /**
     * @}
     */
@@ -184,14 +182,14 @@ extern "C" {
     * @{
     */
     LLVMAttributeBuilderRef LLVMCreateAttributeBuilder( );
-    LLVMAttributeBuilderRef LLVMCreateAttributeBuilder2( LLVMAttributeValue value );
+    LLVMAttributeBuilderRef LLVMCreateAttributeBuilder2( LLVMAttributeRef value );
     LLVMAttributeBuilderRef LLVMCreateAttributeBuilder3( LLVMAttributeSet attributeSet, unsigned index );
     void LLVMAttributeBuilderDispose( LLVMAttributeBuilderRef bldr );
 
     void LLVMAttributeBuilderClear( LLVMAttributeBuilderRef bldr );
 
     void LLVMAttributeBuilderAddEnum( LLVMAttributeBuilderRef bldr, LLVMAttrKind kind );
-    void LLVMAttributeBuilderAddAttribute( LLVMAttributeBuilderRef bldr, LLVMAttributeValue value );
+    void LLVMAttributeBuilderAddAttribute( LLVMAttributeBuilderRef bldr, LLVMAttributeRef value );
     void LLVMAttributeBuilderAddStringAttribute( LLVMAttributeBuilderRef bldr, char const* name, char const* value );
     void LLVMAttributeBuilderRemoveEnum( LLVMAttributeBuilderRef bldr, LLVMAttrKind kind );
     void LLVMAttributeBuilderRemoveAttributes( LLVMAttributeBuilderRef bldr, LLVMAttributeSet attributeSet, unsigned index );

--- a/src/LibLLVM/BuildLlvmWithVS.cmd
+++ b/src/LibLLVM/BuildLlvmWithVS.cmd
@@ -14,7 +14,7 @@ set LLVM_ROOT=%~d0%~p0
 set GENERATE=1
 set BUILD=1
 set REGISTER=1
-set LlvmVersion=3.8.1
+set LlvmVersion=3.9.0
 
 @REM - Allow overriding default version and disabling any of the stages via parameters
 :arg_loop
@@ -90,7 +90,7 @@ goto :exit
 @echo     -g- disables the cmake project generation phase
 @echo     -b- disables the code build phase 
 @echo     -r- disables the registry update
-@echo     -v ^<LlvmVersion^> sets the LLVM version number used for the registry entry (Default is 3.8.1)
+@echo     -v ^<LlvmVersion^> sets the LLVM version number used for the registry entry (Default is 3.9.0)
 @echo.
 @echo The registry entry is used by the LlvmApplication.props Propertysheet for VC projects to locate the various
 @echo LLVM headers and libs. Alternatively, if LLVM_SRCROOT_DIR is provided either as an environment variable

--- a/src/LibLLVM/EXPORTS.DEF
+++ b/src/LibLLVM/EXPORTS.DEF
@@ -787,9 +787,9 @@ LLVMX86FP80Type
 LLVMX86FP80TypeInContext
 LLVMX86MMXType
 LLVMX86MMXTypeInContext
-LLVMInitializeCppBackendTarget
-LLVMInitializeCppBackendTargetInfo
-LLVMInitializeCppBackendTargetMC
+;LLVMInitializeCppBackendTarget
+;LLVMInitializeCppBackendTargetInfo
+;LLVMInitializeCppBackendTargetMC
 LLVMAddGlobalMapping
 LLVMAddModule
 LLVMCreateExecutionEngineForModule
@@ -857,7 +857,7 @@ LLVMPassManagerBuilderSetOptLevel
 LLVMPassManagerBuilderSetSizeLevel
 LLVMPassManagerBuilderUseInlinerWithThreshold
 LLVMParseIRInContext
-LLVMLinkModules
+LLVMLinkModules2 ; Previous version was deprecated in 3.8 and replaced, 3.90 removes it
 LLVMCreateDisasm
 LLVMCreateDisasmCPU
 LLVMCreateDisasmCPUFeatures
@@ -976,7 +976,7 @@ LLVMInitializeSystemZDisassembler
 LLVMInitializeSystemZTargetInfo
 LLVMABIAlignmentOfType
 LLVMABISizeOfType
-LLVMAddTargetData
+;LLVMAddTargetData ; removed in 3.9.0
 LLVMAddTargetLibraryInfo
 LLVMByteOrder
 LLVMCallFrameAlignmentOfType
@@ -1006,7 +1006,7 @@ LLVMGetTargetDescription
 LLVMGetTargetFromName
 LLVMGetTargetFromTriple
 LLVMGetTargetMachineCPU
-LLVMGetTargetMachineData
+LLVMCreateTargetDataLayout; LLVMGetTargetMachineData - renamed in 3.9.0
 LLVMGetTargetMachineFeatureString
 LLVMGetTargetMachineTarget
 LLVMGetTargetMachineTriple

--- a/src/LibLLVM/IRBindings.cpp
+++ b/src/LibLLVM/IRBindings.cpp
@@ -164,44 +164,22 @@ extern "C"
         switch( Ordering )
         {
         case LLVMAtomicOrderingNotAtomic:
-            return NotAtomic;
+            return AtomicOrdering::NotAtomic;
         case LLVMAtomicOrderingUnordered:
-            return Unordered;
+            return AtomicOrdering::Unordered;
         case LLVMAtomicOrderingMonotonic:
-            return Monotonic;
+            return AtomicOrdering::Monotonic;
         case LLVMAtomicOrderingAcquire:
-            return Acquire;
+            return AtomicOrdering::Acquire;
         case LLVMAtomicOrderingRelease:
-            return Release;
+            return AtomicOrdering::Release;
         case LLVMAtomicOrderingAcquireRelease:
-            return AcquireRelease;
+            return AtomicOrdering::AcquireRelease;
         case LLVMAtomicOrderingSequentiallyConsistent:
-            return SequentiallyConsistent;
+            return AtomicOrdering::SequentiallyConsistent;
         }
 
         llvm_unreachable( "Invalid LLVMAtomicOrdering value!" );
-    }
-
-    LLVMValueRef LLVMBuildAtomicCmpXchg( LLVMBuilderRef B
-                                         , LLVMValueRef Ptr
-                                         , LLVMValueRef Cmp
-                                         , LLVMValueRef New
-                                         , LLVMAtomicOrdering successOrdering
-                                         , LLVMAtomicOrdering failureOrdering
-                                         , LLVMBool singleThread
-                                         )
-    {
-        auto builder = unwrap(B);
-        auto cmpxchg = builder->CreateAtomicCmpXchg( unwrap( Ptr )
-                                                     , unwrap( Cmp )
-                                                     , unwrap( New )
-                                                     , mapFromLLVMOrdering( successOrdering )
-                                                     , mapFromLLVMOrdering( failureOrdering )
-                                                     , singleThread ? SingleThread : CrossThread
-                                                     );
-
-
-        return wrap( cmpxchg );
     }
 
     LLVMBool LLVMFunctionHasPersonalityFunction( LLVMValueRef function )

--- a/src/LibLLVM/LlvmApplication.props
+++ b/src/LibLLVM/LlvmApplication.props
@@ -8,12 +8,12 @@
               Therefore, these are all done in an unlabeled group that precedes the UserMacros group visible in the IDE
         -->
     <LlvmVersionMajor Condition="'$(LlvmVersionMajor)'==''">3</LlvmVersionMajor>
-    <llvmVersionMinor Condition="'$(llvmVersionMinor)'==''">8</llvmVersionMinor>
-    <LlvmVersionBuild Condition="'$(LlvmVersionBuild)'==''">1</LlvmVersionBuild>
+    <llvmVersionMinor Condition="'$(llvmVersionMinor)'==''">9</llvmVersionMinor>
+    <LlvmVersionBuild Condition="'$(LlvmVersionBuild)'==''">0</LlvmVersionBuild>
     <LLVM_VERSION Condition="'$(LLVM_VERSION)'==''">$(LlvmVersionMajor).$(llvmVersionMinor).$(LlvmVersionBuild)</LLVM_VERSION>
     <!-- Source ROOT Dir contains the full source of LLVM. To support both developer and automated build service
-             scenarios try user registry, then HKLM-64 and HKLM-32 in that order
-        -->
+         scenarios try user registry, then HKLM-64 and HKLM-32 in that order
+    -->
     <LLVM_SRCROOT_DIR Condition="'$(LLVM_SRCROOT_DIR)'==''">$([MSBuild]::GetRegistryValue(`HKEY_CURRENT_USER\Software\LLVM\$(LLVM_VERSION)\`, `SrcRoot`))</LLVM_SRCROOT_DIR>
     <LLVM_SRCROOT_DIR Condition="'$(LLVM_SRCROOT_DIR)'==''">$([MSBuild]::GetRegistryValueFromView(`HKEY_LOCAL_MACHINE\Software\LLVM\$(LLVM_VERSION)\`, `SrcRoot`, null, RegistryView.Registry64, RegistryView.Registry32))</LLVM_SRCROOT_DIR>
     <LLVM_SRCROOT_DIR Condition="'$(LLVM_SRCROOT_DIR)'!='' AND !HasTrailingSlash('$(LLVM_SRCROOT_DIR)')">$(LLVM_SRCROOT_DIR)\</LLVM_SRCROOT_DIR>
@@ -40,9 +40,9 @@
     <LLVM_INCLUDE>$(LLVM_SRCROOT_DIR)Include</LLVM_INCLUDE>
     <!-- Build is assumed to contain the following sub directories -->
     <!-- CMake doesn't support generating unified solutions/projects for multiple platforms
-             Therefore, the Build folder should contain a sub folder for each targeted platform
-             where CMAKe has generated all the project and solution files for that platform.
-        -->
+         Therefore, the Build folder should contain a sub folder for each targeted platform
+         where CMAKe has generated all the project and solution files for that platform.
+    -->
     <LLVM_PLATFORM_DIR>$(LLVM_BUILD_DIR)$(Platform)\</LLVM_PLATFORM_DIR>
     <!-- Config Directory contains the output of the build for a given configuration (e.g. Debug, Release, RelWithDebInfo) -->
     <LLVM_CONFIG_DIR>$(LLVM_PLATFORM_DIR)$(Configuration)\</LLVM_CONFIG_DIR>
@@ -63,7 +63,7 @@
     <ClCompile>
       <AdditionalOptions>$(AdditionalOptions) /Zc:sizedDealloc-</AdditionalOptions>
       <AdditionalIncludeDirectories>$(LLVM_CONFIG_INCLUDE);$(LLVM_INCLUDE);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4141;4267;4244;4800;4291;4996;4624</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4141;4146;4267;4244;4800;4291;4996;4624</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(AllLlvmStaticLibs);$(AdditionalDependencies)</AdditionalDependencies>

--- a/src/LibLLVM/ValueBindings.h
+++ b/src/LibLLVM/ValueBindings.h
@@ -8,36 +8,6 @@
 extern "C" {
 #endif
 
-    enum LLVMValueKind
-    {
-        LLVMValueKindArgumentVal,              // This is an instance of Argument
-        LLVMValueKindBasicBlockVal,            // This is an instance of BasicBlock
-        LLVMValueKindFunctionVal,              // This is an instance of Function
-        LLVMValueKindGlobalAliasVal,           // This is an instance of GlobalAlias
-        LLVMValueKindGlobalVariableVal,        // This is an instance of GlobalVariable
-        LLVMValueKindUndefValueVal,            // This is an instance of UndefValue
-        LLVMValueKindBlockAddressVal,          // This is an instance of BlockAddress
-        LLVMValueKindConstantExprVal,          // This is an instance of ConstantExpr
-        LLVMValueKindConstantAggregateZeroVal, // This is an instance of ConstantAggregateZero
-        LLVMValueKindConstantDataArrayVal,     // This is an instance of ConstantDataArray
-        LLVMValueKindConstantDataVectorVal,    // This is an instance of ConstantDataVector
-        LLVMValueKindConstantIntVal,           // This is an instance of ConstantInt
-        LLVMValueKindConstantFPVal,            // This is an instance of ConstantFP
-        LLVMValueKindConstantArrayVal,         // This is an instance of ConstantArray
-        LLVMValueKindConstantStructVal,        // This is an instance of ConstantStruct
-        LLVMValueKindConstantVectorVal,        // This is an instance of ConstantVector
-        LLVMValueKindConstantPointerNullVal,   // This is an instance of ConstantPointerNull
-        LLVMValueKindMetadataAsValueVal,       // This is an instance of MetadataAsValue
-        LLVMValueKindInlineAsmVal,             // This is an instance of InlineAsm
-        LLVMValueKindInstructionVal,           // This is an instance of Instruction
-                                               // Enum values starting at InstructionVal are used for Instructions;
-
-                                               // Markers:
-        LLVMValueKindConstantFirstVal = LLVMValueKindFunctionVal,
-        LLVMValueKindConstantLastVal = LLVMValueKindConstantPointerNullVal
-    };
-
-
     LLVMBool LLVMIsConstantZeroValue( LLVMValueRef valueRef );
     void LLVMRemoveGlobalFromParent( LLVMValueRef valueRef );
     

--- a/src/Llvm.NET/Enumerations.cs
+++ b/src/Llvm.NET/Enumerations.cs
@@ -365,14 +365,6 @@ namespace Llvm.NET
         BigEndian = LLVMByteOrdering.LLVMBigEndian
     }
 
-    /// <summary>LLVM module linker mode</summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Design", "CA1028:EnumStorageShouldBeInt32" )]
-    public enum LinkerMode : uint
-    {
-        DestroySource = LLVMLinkerMode.LLVMLinkerDestroySource,
-        PreserveSource = LLVMLinkerMode.LLVMLinkerPreserveSource
-    }
-
     /// <summary>Enumeration for well known attribute kinds</summary>
     /// <remarks>
     /// The numeric value of the members of this enumeration are subject
@@ -385,7 +377,7 @@ namespace Llvm.NET
     /// the numerical values.
     /// </Implementation>
     public enum AttributeKind
-    {
+    {  // TODO: update for attributes added in 3.9.0...
         None                        = LLVMAttrKind.None,
         Alignment                   = LLVMAttrKind.Alignment,
         AlwaysInline                = LLVMAttrKind.AlwaysInline,

--- a/src/Llvm.NET/LLVM/Generated.cs
+++ b/src/Llvm.NET/LLVM/Generated.cs
@@ -865,12 +865,6 @@ namespace Llvm.NET.Native
         @LTO_DS_NOTE = 2,
     }
 
-    internal enum LLVMLinkerMode : uint
-    {
-        @LLVMLinkerDestroySource = 0, /* Allow source module to be destroyed. */
-        @LLVMLinkerPreserveSource = 1 /* Preserve the source module. */
-    }
-
     internal static partial class NativeMethods
     {
         private const string libraryPath = "LibLlvm.dll";
@@ -2509,8 +2503,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeNVPTXTargetInfo", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeNVPTXTargetInfo();
 
-        [DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTargetInfo", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern void InitializeCppBackendTargetInfo();
+        //[DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTargetInfo", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        //internal static extern void InitializeCppBackendTargetInfo();
 
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeMSP430TargetInfo", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeMSP430TargetInfo();
@@ -2548,8 +2542,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeNVPTXTarget", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeNVPTXTarget();
 
-        [DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTarget", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern void InitializeCppBackendTarget();
+        //[DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTarget", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        //internal static extern void InitializeCppBackendTarget();
 
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeMSP430Target", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeMSP430Target();
@@ -2587,8 +2581,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeNVPTXTargetMC", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeNVPTXTargetMC();
 
-        [DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTargetMC", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern void InitializeCppBackendTargetMC();
+        //[DllImport(libraryPath, EntryPoint = "LLVMInitializeCppBackendTargetMC", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        //internal static extern void InitializeCppBackendTargetMC();
 
         [DllImport(libraryPath, EntryPoint = "LLVMInitializeMSP430TargetMC", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void InitializeMSP430TargetMC();
@@ -2734,8 +2728,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMCreateTargetData", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern LLVMTargetDataRef CreateTargetData([MarshalAs(UnmanagedType.LPStr)] string @StringRep);
 
-        [DllImport(libraryPath, EntryPoint = "LLVMAddTargetData", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern void AddTargetData(LLVMTargetDataRef @TD, LLVMPassManagerRef @PM);
+        //[DllImport(libraryPath, EntryPoint = "LLVMAddTargetData", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        //internal static extern void AddTargetData(LLVMTargetDataRef @TD, LLVMPassManagerRef @PM);
 
         [DllImport(libraryPath, EntryPoint = "LLVMAddTargetLibraryInfo", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void AddTargetLibraryInfo(LLVMTargetLibraryInfoRef @TLI, LLVMPassManagerRef @PM);
@@ -2839,8 +2833,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMGetTargetMachineFeatureString", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern IntPtr GetTargetMachineFeatureString(LLVMTargetMachineRef @T);
 
-        [DllImport(libraryPath, EntryPoint = "LLVMGetTargetMachineData", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern LLVMTargetDataRef GetTargetMachineData(LLVMTargetMachineRef @T);
+        [DllImport(libraryPath, EntryPoint = "LLVMCreateTargetDataLayout", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern LLVMTargetDataRef CreateTargetDataLayout(LLVMTargetMachineRef @T);
 
         [DllImport(libraryPath, EntryPoint = "LLVMSetTargetMachineAsmVerbosity", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern void SetTargetMachineAsmVerbosity(LLVMTargetMachineRef @T, LLVMBool @VerboseAsm);
@@ -2992,8 +2986,8 @@ namespace Llvm.NET.Native
         [DllImport(libraryPath, EntryPoint = "LLVMParseIRInContext", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern LLVMBool ParseIRInContext(LLVMContextRef @ContextRef, LLVMMemoryBufferRef @MemBuf, out LLVMModuleRef @OutM, out IntPtr @OutMessage);
 
-        [DllImport(libraryPath, EntryPoint = "LLVMLinkModules", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern LLVMBool LinkModules(LLVMModuleRef @Dest, LLVMModuleRef @Src, LLVMLinkerMode @Mode, out IntPtr @OutMessage);
+        [DllImport(libraryPath, EntryPoint = "LLVMLinkModules2", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        internal static extern LLVMBool LinkModules(LLVMModuleRef @Dest, LLVMModuleRef @Src );
 
         [DllImport(libraryPath, EntryPoint = "LLVMCreateObjectFile", CallingConvention = System.Runtime.InteropServices.CallingConvention.Cdecl, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         internal static extern LLVMObjectFileRef CreateObjectFile(LLVMMemoryBufferRef @MemBuf);

--- a/src/Llvm.NET/LLVM/GeneratedExtensions.cs
+++ b/src/Llvm.NET/LLVM/GeneratedExtensions.cs
@@ -78,35 +78,38 @@ namespace Llvm.NET.Native
         @ModFlagBehaviorLastVal = AppendUnique
     }
 
-    internal enum LLVMValueKind : int
+    internal enum LLVMValueKind
     {
-        @LLVMValueKindArgumentVal,              // This is an instance of Argument
-        @LLVMValueKindBasicBlockVal,            // This is an instance of BasicBlock
-        @LLVMValueKindFunctionVal,              // This is an instance of Function
-        @LLVMValueKindGlobalAliasVal,           // This is an instance of GlobalAlias
-        @LLVMValueKindGlobalVariableVal,        // This is an instance of GlobalVariable
-        @LLVMValueKindUndefValueVal,            // This is an instance of UndefValue
-        @LLVMValueKindBlockAddressVal,          // This is an instance of BlockAddress
-        @LLVMValueKindConstantExprVal,          // This is an instance of ConstantExpr
-        @LLVMValueKindConstantAggregateZeroVal, // This is an instance of ConstantAggregateZero
-        @LLVMValueKindConstantDataArrayVal,     // This is an instance of ConstantDataArray
-        @LLVMValueKindConstantDataVectorVal,    // This is an instance of ConstantDataVector
-        @LLVMValueKindConstantIntVal,           // This is an instance of ConstantInt
-        @LLVMValueKindConstantFPVal,            // This is an instance of ConstantFP
-        @LLVMValueKindConstantArrayVal,         // This is an instance of ConstantArray
-        @LLVMValueKindConstantStructVal,        // This is an instance of ConstantStruct
-        @LLVMValueKindConstantVectorVal,        // This is an instance of ConstantVector
-        @LLVMValueKindConstantPointerNullVal,   // This is an instance of ConstantPointerNull
-        @LLVMValueKindConstantTokenNoneVal,     // This is an instance of ConstantTokenNull
-        @LLVMValueKindMetadataAsValueVal,       // This is an instance of MetadataAsValue
-        @LLVMValueKindInlineAsmVal,             // This is an instance of InlineAsm
-        @LLVMValueKindInstructionVal,           // This is an instance of Instruction
-                                                // Enum values starting at InstructionVal are used for Instructions;
+        LLVMArgumentValueKind,
+        LLVMBasicBlockValueKind,
+        LLVMMemoryUseValueKind,
+        LLVMMemoryDefValueKind,
+        LLVMMemoryPhiValueKind,
 
-        // Markers:
-        @LLVMValueKindConstantFirstVal = LLVMValueKindFunctionVal,
-        @LLVMValueKindConstantLastVal = LLVMValueKindConstantPointerNullVal
-    };
+        LLVMFunctionValueKind,
+        LLVMGlobalAliasValueKind,
+        LLVMGlobalIFuncValueKind,
+        LLVMGlobalVariableValueKind,
+        LLVMBlockAddressValueKind,
+        LLVMConstantExprValueKind,
+        LLVMConstantArrayValueKind,
+        LLVMConstantStructValueKind,
+        LLVMConstantVectorValueKind,
+
+        LLVMUndefValueValueKind,
+        LLVMConstantAggregateZeroValueKind,
+        LLVMConstantDataArrayValueKind,
+        LLVMConstantDataVectorValueKind,
+        LLVMConstantIntValueKind,
+        LLVMConstantFPValueKind,
+        LLVMConstantPointerNullValueKind,
+        LLVMConstantTokenNoneValueKind,
+
+        LLVMMetadataAsValueValueKind,
+        LLVMInlineAsmValueKind,
+
+        LLVMInstructionValueKind,
+    }
 
     enum LLVMDwarfTag : ushort
     {
@@ -187,11 +190,14 @@ namespace Llvm.NET.Native
         LLVMDwarfTagAppleProperty = 0x4200,
         LLVMDwarfTagHiUser = 0xffff
     };
-
+    
+    // values and ordering extracted from LLVM's Attributes.inc
+    // which is used to construct the Attribute::AttributeKind enumeration
     internal enum LLVMAttrKind
     {
         None,
         Alignment,
+        AllocSize,
         AlwaysInline,
         ArgMemOnly,
         Builtin,
@@ -237,6 +243,8 @@ namespace Llvm.NET.Native
         StackProtectReq,
         StackProtectStrong,
         StructRet,
+        SwiftError,
+        SwiftSelf,
         UWTable,
         ZExt,
     };

--- a/src/Llvm.NET/LLVM/LLVMNative.cs
+++ b/src/Llvm.NET/LLVM/LLVMNative.cs
@@ -5,34 +5,41 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading;
-using Llvm.NET.Values;
 
 namespace Llvm.NET.Native
 {
     internal enum ValueKind : uint
     {
-        Argument              = LLVMValueKind.LLVMValueKindArgumentVal,             // This is an instance of Argument
-        BasicBlock            = LLVMValueKind.LLVMValueKindBasicBlockVal,           // This is an instance of BasicBlock
-        Function              = LLVMValueKind.LLVMValueKindFunctionVal,             // This is an instance of Function
-        GlobalAlias           = LLVMValueKind.LLVMValueKindGlobalAliasVal,          // This is an instance of GlobalAlias
-        GlobalVariable        = LLVMValueKind.LLVMValueKindGlobalVariableVal,       // This is an instance of GlobalVariable
-        UndefValue            = LLVMValueKind.LLVMValueKindUndefValueVal,           // This is an instance of UndefValue
-        BlockAddress          = LLVMValueKind.LLVMValueKindBlockAddressVal,         // This is an instance of BlockAddress
-        ConstantExpr          = LLVMValueKind.LLVMValueKindConstantExprVal,         // This is an instance of ConstantExpr
-        ConstantAggregateZero = LLVMValueKind.LLVMValueKindConstantAggregateZeroVal,// This is an instance of ConstantAggregateZero
-        ConstantDataArray     = LLVMValueKind.LLVMValueKindConstantDataArrayVal,    // This is an instance of ConstantDataArray
-        ConstantDataVector    = LLVMValueKind.LLVMValueKindConstantDataVectorVal,   // This is an instance of ConstantDataVector
-        ConstantInt           = LLVMValueKind.LLVMValueKindConstantIntVal,          // This is an instance of ConstantInt
-        ConstantFP            = LLVMValueKind.LLVMValueKindConstantFPVal,           // This is an instance of ConstantFP
-        ConstantArray         = LLVMValueKind.LLVMValueKindConstantArrayVal,        // This is an instance of ConstantArray
-        ConstantStruct        = LLVMValueKind.LLVMValueKindConstantStructVal,       // This is an instance of ConstantStruct
-        ConstantVector        = LLVMValueKind.LLVMValueKindConstantVectorVal,       // This is an instance of ConstantVector
-        ConstantPointerNull   = LLVMValueKind.LLVMValueKindConstantPointerNullVal,  // This is an instance of ConstantPointerNull
-        ConstantTokenNone     = LLVMValueKind.LLVMValueKindConstantTokenNoneVal,    // This is an instance of ConstantTokenNone
-        MetadataAsValue       = LLVMValueKind.LLVMValueKindMetadataAsValueVal,      // This is an instance of MetadataAsValue
-        InlineAsm             = LLVMValueKind.LLVMValueKindInlineAsmVal,            // This is an instance of InlineAsm
-        Instruction           = LLVMValueKind.LLVMValueKindInstructionVal,          // This is an instance of Instruction
-                                                                                    // Enum values starting at InstructionVal are used for Instructions;
+        Argument              = LLVMValueKind.LLVMArgumentValueKind,              // This is an instance of Argument
+        BasicBlock            = LLVMValueKind.LLVMBasicBlockValueKind,            // This is an instance of BasicBlock
+        MemoryUse             = LLVMValueKind.LLVMMemoryUseValueKind,             // ???
+        MemoryDef             = LLVMValueKind.LLVMMemoryDefValueKind,             // ???
+        MemoryPhi             = LLVMValueKind.LLVMMemoryPhiValueKind,             // ???
+
+        Function              = LLVMValueKind.LLVMFunctionValueKind,              // This is an instance of Function
+        GlobalAlias           = LLVMValueKind.LLVMGlobalAliasValueKind,           // This is an instance of GlobalAlias
+        GlobalIFunc           = LLVMValueKind.LLVMGlobalIFuncValueKind,           // ???
+        GlobalVariable        = LLVMValueKind.LLVMGlobalVariableValueKind,        // This is an instance of GlobalVariable
+        BlockAddress          = LLVMValueKind.LLVMBlockAddressValueKind,          // This is an instance of BlockAddress
+        ConstantExpr          = LLVMValueKind.LLVMConstantExprValueKind,          // This is an instance of ConstantExpr
+        ConstantArray         = LLVMValueKind.LLVMConstantArrayValueKind,         // This is an instance of ConstantArray
+        ConstantStruct        = LLVMValueKind.LLVMConstantStructValueKind,        // This is an instance of ConstantStruct
+        ConstantVector        = LLVMValueKind.LLVMConstantVectorValueKind,        // This is an instance of ConstantVector
+
+        UndefValue            = LLVMValueKind.LLVMUndefValueValueKind,            // This is an instance of UndefValue
+        ConstantAggregateZero = LLVMValueKind.LLVMConstantAggregateZeroValueKind, // This is an instance of ConstantAggregateZero
+        ConstantDataArray     = LLVMValueKind.LLVMConstantDataArrayValueKind,     // This is an instance of ConstantDataArray
+        ConstantDataVector    = LLVMValueKind.LLVMConstantDataVectorValueKind,    // This is an instance of ConstantDataVector
+        ConstantInt           = LLVMValueKind.LLVMConstantIntValueKind,           // This is an instance of ConstantInt
+        ConstantFP            = LLVMValueKind.LLVMConstantFPValueKind,            // This is an instance of ConstantFP
+        ConstantPointerNull   = LLVMValueKind.LLVMConstantPointerNullValueKind,   // This is an instance of ConstantPointerNull
+        ConstantTokenNone     = LLVMValueKind.LLVMConstantTokenNoneValueKind,     // This is an instance of ConstantTokenNone
+
+        MetadataAsValue       = LLVMValueKind.LLVMMetadataAsValueValueKind,       // This is an instance of MetadataAsValue
+        InlineAsm             = LLVMValueKind.LLVMInlineAsmValueKind,             // This is an instance of InlineAsm
+
+        Instruction           = LLVMValueKind.LLVMInstructionValueKind,           // This is an instance of Instruction
+                                                                                  // Enum values starting at InstructionVal are used for Instructions;
 
         // instruction values come directly from LLVM Instruction.def which is different from the "stable"
         // LLVM-C API, therefore they are less "stable" and bound to the C++ implementation version and
@@ -110,7 +117,12 @@ namespace Llvm.NET.Native
 
         // Markers:
         ConstantFirstVal = Function,
-        ConstantLastVal = ConstantPointerNull
+        ConstantLastVal = ConstantTokenNone,
+
+        ConstantDataFirstVal = UndefValue,
+        ConstantDataLastVal = ConstantTokenNone,
+        ConstantAggregateFirstVal = ConstantArray,
+        ConstantAggregateLastVal = ConstantVector,
     }
 
     internal partial struct LLVMVersionInfo
@@ -275,7 +287,7 @@ namespace Llvm.NET.Native
 
         // version info for verification of matched LibLLVM
         private const int VersionMajor = 3;
-        private const int VersionMinor = 8;
+        private const int VersionMinor = 9;
         private const int VersionPatch = 0;
     }
 }

--- a/src/Llvm.NET/Metadata/Metadata.cs
+++ b/src/Llvm.NET/Metadata/Metadata.cs
@@ -55,35 +55,49 @@ namespace Llvm.NET
 
             return ( T )context.GetNodeFor( handle, StaticFactory );
         }
+
         /// <summary>Enumeration to define debug information metadata nodes</summary>
         private enum MetadataKind : uint
         {
-            MDTuple,
-            DILocation,
-            GenericDINode,
-            DISubrange,
-            DIEnumerator,
-            DIBasicType,
-            DIDerivedType,
-            DICompositeType,
-            DISubroutineType,
-            DIFile,
-            DICompileUnit,
-            DISubprogram,
-            DILexicalBlock,
-            DILexicalBlockFile,
-            DINamespace,
-            DIModule,
-            DITemplateTypeParameter,
-            DITemplateValueParameter,
-            DIGlobalVariable,
-            DILocalVariable,
-            DIExpression,
-            DIObjCProperty,
-            DIImportedEntity,
-            ConstantAsMetadata,
-            LocalAsMetadata,
-            MDString
+            MDString,                     // HANDLE_METADATA_LEAF(MDString)
+            //ValueAsMetadata,            // HANDLE_METADATA_BRANCH(ValueAsMetadata)
+            ConstantAsMetadata,           // HANDLE_METADATA_LEAF(ConstantAsMetadata)
+            LocalAsMetadata,              // HANDLE_METADATA_LEAF(LocalAsMetadata)
+            DistinctMDOperandPlaceholder, // HANDLE_METADATA_LEAF(DistinctMDOperandPlaceholder)
+            //MDNode,                     // HANDLE_MDNODE_BRANCH(MDNode)
+            MDTuple,                      // HANDLE_MDNODE_LEAF_UNIQUABLE(MDTuple)
+            DILocation,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocation)
+            DIExpression,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIExpression)
+            //DINode,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DINode)
+            GenericDINode,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(GenericDINode)
+            DISubrange,                   // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubrange)
+            DIEnumerator,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIEnumerator)
+            //DIScope,                    // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIScope)
+            //DIType,                     // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIType)
+            DIBasicType,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIBasicType)
+            DIDerivedType,                // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIDerivedType)
+            DICompositeType,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DICompositeType)
+            DISubroutineType,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubroutineType)
+            DIFile,                       // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIFile)
+            DICompileUnit,                // HANDLE_SPECIALIZED_MDNODE_LEAF(DICompileUnit)
+            //DILocalScope,               // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILocalScope)
+            DISubprogram,                 // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DISubprogram)
+            //DILexicalBlockBase,         // HANDLE_SPECIALIZED_MDNODE_BRANCH(DILexicalBlockBase)
+            DILexicalBlock,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlock)
+            DILexicalBlockFile,           // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILexicalBlockFile)
+            DINamespace,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DINamespace)
+            DIModule,                     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIModule)
+            //DITemplateParameter,        // HANDLE_SPECIALIZED_MDNODE_BRANCH(DITemplateParameter)
+            DITemplateTypeParameter,      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateTypeParameter)
+            DITemplateValueParameter,     // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DITemplateValueParameter)
+            //DIVariable,                 // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIVariable)
+            DIGlobalVariable,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIGlobalVariable)
+            DILocalVariable,              // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DILocalVariable)
+            DIObjCProperty,               // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIObjCProperty)
+            DIImportedEntity,             // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIImportedEntity)
+            //DIMacroNode,                // HANDLE_SPECIALIZED_MDNODE_BRANCH(DIMacroNode)
+            DIMacro,                      // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacro)
+            DIMacroFile,                  // HANDLE_SPECIALIZED_MDNODE_LEAF_UNIQUABLE(DIMacroFile)
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage( "Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "Static factory method" )]

--- a/src/Llvm.NET/Module.cs
+++ b/src/Llvm.NET/Module.cs
@@ -280,19 +280,20 @@ namespace Llvm.NET
             }
         }
 
-        /// <summary>Link another bit-code module into the current module</summary>
-        /// <param name="otherModule">Module to merge into this one</param>
-        /// <param name="linkMode">Linker mode to use when merging</param>
-        public void Link( NativeModule otherModule, LinkerMode linkMode )
+        public void Link( NativeModule otherModule )
         {
             if( otherModule == null )
                 throw new ArgumentNullException( nameof( otherModule ) );
 
-            IntPtr errMsgPtr;
-            if( 0 != NativeMethods.LinkModules( ModuleHandle, otherModule.ModuleHandle, ( LLVMLinkerMode )linkMode, out errMsgPtr ).Value )
+            // TODO: need to hook up context error diagnostic reporting mechanism
+            // as underlying LLVM functionality now uses that instead of providing
+            // error messages as an out parameter.
+
+            //IntPtr errMsgPtr;
+            if( !NativeMethods.LinkModules( ModuleHandle, otherModule.ModuleHandle ).Succeeded )
             {
-                var errMsg = NativeMethods.MarshalMsg( errMsgPtr );
-                throw new InternalCodeGeneratorException( errMsg );
+                //var errMsg = NativeMethods.MarshalMsg( errMsgPtr );
+                throw new InternalCodeGeneratorException( "Module link error" );
             }
         }
 

--- a/src/Llvm.NET/TargetMachine.cs
+++ b/src/Llvm.NET/TargetMachine.cs
@@ -18,17 +18,12 @@ namespace Llvm.NET
         /// <summary>CPU specific features for this machine</summary>
         public string Features => NativeMethods.MarshalMsg( NativeMethods.GetTargetMachineFeatureString( TargetMachineHandle ) );
 
-        /// <summary>Layout information for this machine</summary>
-        /// <remarks>
-        /// <note type="warning">This property is currently planned for removal in LLVM v4.0.
-        /// Though it is unclear what the replacement will be as there is no other way to get
-        /// the layout information if it isn't already known.</note>
-        /// </remarks>
+        /// <summary>Gets Layout information for this machine</summary>
         public DataLayout TargetData
         {
             get
             {
-                var handle = NativeMethods.GetTargetMachineData( TargetMachineHandle );
+                var handle = NativeMethods.CreateTargetDataLayout( TargetMachineHandle );
                 if( handle.Pointer == IntPtr.Zero )
                     return null;
 

--- a/src/Llvm.NETTests/LLVM.NETTests/TargetTests.cs
+++ b/src/Llvm.NETTests/LLVM.NETTests/TargetTests.cs
@@ -49,7 +49,7 @@ namespace Llvm.NET.Tests
             new TargetInfo( "mipsel", "Mipsel", true, true, true ),
             new TargetInfo( "mips", "Mips", true, true, true ),
             new TargetInfo( "hexagon", "Hexagon", true, false, true ),
-            new TargetInfo( "cpp", "C++ backend", false, false, true ),
+            //new TargetInfo( "cpp", "C++ backend", false, false, true ),
             new TargetInfo( "bpfeb", "BPF (big endian)", true, true, true ),
             new TargetInfo( "bpfel", "BPF (little endian)", true, true, true ),
             new TargetInfo( "bpf", "BPF (host endian)", true, true, true ),

--- a/src/Llvm.NETTests/LLVM.NETTests/TestModuleAsString.ll
+++ b/src/Llvm.NETTests/LLVM.NETTests/TestModuleAsString.ll
@@ -1,4 +1,5 @@
 ﻿; ModuleID = 'test'
+source_filename = "test"
 
 define void @foo() {
 entry:

--- a/src/Llvm.NETTests/LLVM.NETTests/Values/AttributeValueTests.cs
+++ b/src/Llvm.NETTests/LLVM.NETTests/Values/AttributeValueTests.cs
@@ -56,7 +56,7 @@ namespace Llvm.NET.Values.Tests
                 Assert.IsFalse( value.IsString );
                 Assert.IsNull( value.Name );
                 Assert.IsNull( value.StringValue );
-                Assert.IsFalse( value.IsEnum );
+                Assert.IsTrue( value.IsEnum );
                 Assert.IsTrue( value.Kind.HasValue );
                 Assert.AreEqual( AttributeKind.DereferenceableOrNull, value.Kind.Value );
                 Assert.AreEqual( value.IntegerValue, 1234ul );


### PR DESCRIPTION
This commit covers the basic changes required for LLVM.NET to build and run. Additional changes are needed to completely cover new features and functionality added in

LLVM 3.9.0
Summary:
- removed use of custom LLVMAttributeValue in favor of new LLVMAttributeRef
- Removed  custom attribute functions with conflicting names where LLVM has added the same functionality into the official C API
- remapped the LLVMAttrKind enumeration values to match LLVM's (looks like there were some errors in LLVM.NET for 3.8.0 on this)
- removed custom (and now redundant) LLVMValueKind enumeration as LLVM includes an enumeration for value kinds now
- Modified Module.Link calls to remove "mode" and error message params no longer supported in LLVM 3.9.0
- Updated internal MetadaKind enum to map to current LLVM IDs
- updated disabled warnings for LLVM headers
- updated attributes file for repo
