### PR TITLE
Extended NativeModule to support in-memory output 

### DIFF
--- a/src/Llvm.NET/Module.cs
+++ b/src/Llvm.NET/Module.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using Llvm.NET.DebugInfo;
 using Llvm.NET.Native;
 using Llvm.NET.Types;
@@ -367,6 +368,30 @@ namespace Llvm.NET
 
             errMsg = NativeMethods.MarshalMsg( msg );
             return false;
+        }
+
+        /// <summary>Write this module as LLVM IR bitcode to a memory buffer</summary>
+        /// <returns>The resulting IR bitcode as byte array</returns>
+        public byte[] WriteToBuffer( )
+        {
+            var bufferRef = NativeMethods.WriteBitcodeToMemoryBuffer( ModuleHandle );
+            if( bufferRef.Pointer == IntPtr.Zero )
+                throw new IOException( "Could not write to buffer" );
+
+            try
+            {
+                var bufferStart = NativeMethods.GetBufferStart( bufferRef );
+                var bufferSize = NativeMethods.GetBufferSize( bufferRef );
+
+                var result = new byte[ bufferSize ];
+                Marshal.Copy( bufferStart, result, 0, bufferSize );
+
+                return result;
+            }
+            finally
+            {
+                NativeMethods.DisposeMemoryBuffer( bufferRef );
+            }
         }
 
         /// <summary>Creates a string representation of the module</summary>


### PR DESCRIPTION
Extended _NativeModule_ in order to write llvm-ir bitcode to an in-memory byte array instead of a file